### PR TITLE
Uninitialized string offset fix

### DIFF
--- a/src/HamlPHP/Interpolation.php
+++ b/src/HamlPHP/Interpolation.php
@@ -26,7 +26,7 @@ class Interpolation
 
     while ($i < $len) {
       $currentChar = $this->_text[$i];
-      $nextChar = ($i + 1 <= $len) ? $this->_text[$i + 1] : null;
+      $nextChar = ($i + 1 <= $len - 1) ? $this->_text[$i + 1] : null;
 
       if ($interpolationStarted) {
         if ($currentChar === '}') {


### PR DESCRIPTION
When updating haml templates (with E_NOTICE turned on) this notice is given a few times when the changes are parsed.
The reason for the - 1 is because while $len is equal to the length of the string, arrays start with 0 (as does $i.)

It solved the notice for me without any problems and I hope it makes sense?
